### PR TITLE
bump spring version from 5.3.x users should upgrade to 5.3.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<properties>
 		
-		<org.springframework-version>5.3.27</org.springframework-version>
+		<org.springframework-version>5.3.32</org.springframework-version>
 
 		<picocli-version>4.6.3</picocli-version>
 		


### PR DESCRIPTION
as the official docs say

<img width="1418" alt="Screenshot 2024-02-23 at 1 55 36 PM" src="https://github.com/ESIPFed/Geoweaver/assets/45752727/df03e728-64fd-4f77-82fe-6bbf7ae83b37">
