### PR TITLE
fixed the chart visibility issue and table actions in side panel

### DIFF
--- a/src/main/resources/static/js/gw.chart.js
+++ b/src/main/resources/static/js/gw.chart.js
@@ -164,7 +164,7 @@ GW.chart = {
 			
 		},
 		
-		renderUtil: function(type, msg){
+		renderUtil: function(type, msg, process_history_container_id){
 			
 			this.utils.srand(Date.now());
 			
@@ -342,6 +342,12 @@ GW.chart = {
 			$('#'+ type + '-history-chart').html("")
 			
 			var ctx = document.getElementById( type + '-history-chart').getContext('2d');
+
+			// if the type is process then getting the right history chart from the right parent container
+			if(type == "process" && process_history_container_id !== null){
+				let chart_parent_container = document.querySelector(process_history_container_id);
+				ctx = chart_parent_container.querySelector('#' + type + '-history-chart').getContext('2d');
+			}
 			var config = {
 				type: 'line',
 				data: {
@@ -412,11 +418,11 @@ GW.chart = {
 		},
 
 		
-		renderProcessHistoryChart: function(msg){
+		renderProcessHistoryChart: function(msg, process_history_container_id){
 			msg = msg.sort(function(x, y) {
 				return x['history_begin_time'] - y['history_begin_time'];
 			})
-			this.renderUtil("process", msg);
+			this.renderUtil("process", msg, process_history_container_id);
 			
 		},
 		

--- a/src/main/resources/static/js/gw.history.js
+++ b/src/main/resources/static/js/gw.history.js
@@ -371,7 +371,7 @@ GW.history = {
 
     applyBootstrapTable: function(table_id){
 
-        var table = $("#"+table_id).DataTable({
+        var table = $(table_id).DataTable({
             columnDefs : [
                 { type: 'time-date-sort',
                   targets: [1],

--- a/src/main/resources/static/js/gw.process.sidepanel.js
+++ b/src/main/resources/static/js/gw.process.sidepanel.js
@@ -483,7 +483,7 @@ GW.process.sidepanel = {
 
     history: function(process_id, process_name){
 
-        GW.process.util.history(process_id, "#prompt-panel-process-history-container", 'process_history_table', 
+        GW.process.util.history(process_id, "#prompt-panel-process-history-container", '#process_history_table', 
 			"#closeHistory", "prompt-panel-main-process-info-history-tab", "prompt-panel-main-process-info-history")
 
     },

--- a/src/main/resources/static/js/gw.process.util.js
+++ b/src/main/resources/static/js/gw.process.util.js
@@ -375,9 +375,10 @@ GW.process.util = {
 
 			GW.history.startActiveTimer();
 
-			GW.history.applyBootstrapTable(process_history_table_id);
+			var table_selector = `${process_history_container_id} ${process_history_table_id}`;
+			GW.history.applyBootstrapTable(table_selector);
 			
-			GW.chart.renderProcessHistoryChart(msg);
+			GW.chart.renderProcessHistoryChart(msg, process_history_container_id);
 			
 			$(close_history).click(function(){
 				


### PR DESCRIPTION
This PR is for #445 issue.
Fixed the chart rendering issue in side panel caused due to multiple chart containers being in the document at the same time and accesing the first chart always. Fixed by providing the right selector for the chart container which targets right container and renders properly.