### PR TITLE
Add process download option #270

### DIFF
--- a/src/main/resources/static/js/gw.process.sidepanel.js
+++ b/src/main/resources/static/js/gw.process.sidepanel.js
@@ -300,7 +300,10 @@ GW.process.sidepanel = {
                 <button class="btn pull-right" title="switch on/off log" onclick="javascript:void(0)">
                     Log: <input type="checkbox" id="prompt_panel_log_switch" checked="checked" />
                 </button>
-                <button class="btn pull-right" title="execute process" onclick="GW.process.sidepanel.runProcess('` +
+                <button class="btn pull-right" title="download code" onclick="GW.process.sidepanel.getCodeAndLog()">
+                <i class="glyphicon glyphicon-download"></i>
+            </button>  
+              <button class="btn pull-right" title="execute process" onclick="GW.process.sidepanel.runProcess('` +
       this.current_process_id +
       `', '` +
       this.current_process_name +
@@ -531,4 +534,11 @@ GW.process.sidepanel = {
   isPresent: function () {
     return $("#prompt-panel").hasClass("cd-panel--is-visible");
   },
+  getCodeAndLog: function(){
+    var code = this.getCode();
+    var log = $("#prompt-panel-process-log-window").html();
+    var code_log = code + "\n\n" + log;
+    var blob = new Blob([code_log], {type: "text/plain;charset=utf-8"});
+    saveAs(blob, "code_log.txt");
+},
 };


### PR DESCRIPTION
Video Demo Available:
https://github.com/ESIPFed/Geoweaver/assets/75781772/72cd2004-8182-4f02-b7df-603f229c9346

The issue pertaining to downloading the process has been successfully resolved. A solution has been implemented by introducing a button within the side panel. Upon clicking this designated button, users can now seamlessly download the process code.