### PR TITLE
Docker image

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -102,7 +102,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/geoweaver:${{ env.VERSION }}, ${{ secrets.DOCKER_USERNAME }}/geoweaver:latest
+          tags: geoweaver/geoweaver:${{ env.VERSION }}, geoweaver/geoweaver:latest
 
       - name: Logout from Docker
         if: always()

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: geoweaver
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -102,7 +102,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/geoweaver:${{ env.VERSION }}
+          tags: ${{ secrets.DOCKER_USERNAME }}/geoweaver:${{ env.VERSION }}, ${{ secrets.DOCKER_USERNAME }}/geoweaver:latest
 
       - name: Logout from Docker
         if: always()

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -86,6 +86,27 @@ jobs:
             pom.xml
             linux-deployment/*.deb
             
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/geoweaver:${{ env.VERSION }}
+
+      - name: Logout from Docker
+        if: always()
+        run: docker logout        
 
   build-windows:
       needs: build-jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-From openjdk:11
-
-COPY --from=python:3.8 / /
+FROM openjdk:11
 
 COPY ./target/geoweaver.jar /opt/
 
@@ -12,4 +10,13 @@ USER marsvegan
 
 WORKDIR /home/marsvegan
 
-ENTRYPOINT ["java","-jar","/opt/geoweaver.jar"]
+ENTRYPOINT ["sh", "-c", "if [ ! -z \"$PASSWORD\" ]; then \
+        echo \"Password provided: $PASSWORD\"; \
+        java -jar /opt/geoweaver.jar resetpassword -p \"$PASSWORD\"; \
+        echo \"Password reset completed.\"; \
+        java -jar /opt/geoweaver.jar; \
+    else \
+        echo \"No password provided. Skipping password reset.\"; \
+        java -jar /opt/geoweaver.jar; \
+    fi"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11
+# FROM openjdk:11
+FROM eclipse-temurin:17
 
 COPY ./target/geoweaver.jar /opt/
 


### PR DESCRIPTION
Added a step in release-workflow in github actions to push the docker image of latest geoweaver along with version as tag to docker hub.

Here is the image link
https://hub.docker.com/layers/geoweaver/geoweaver/1.4.8/images/sha256-63cd093dcc7e0952712e80a48c8283dad489a191bc7863edf35ad7001eeed384?context=repo

To test the image
please use the command below

docker run -it --rm -p 8071:8070 -e PASSWORD="geoweaver" -v geoweaverdata:/home/marsvegan/ geoweaver/geoweaver:1.4.8
