### PR TITLE
debugger-removed(Monaco-workerMain)

### DIFF
--- a/src/main/resources/static/js/Monaco-Editor/dev/vs/base/worker/workerMain.js
+++ b/src/main/resources/static/js/Monaco-Editor/dev/vs/base/worker/workerMain.js
@@ -11308,7 +11308,7 @@ define(__m[8/*vs/editor/common/diff/defaultLinesDiffComputer/algorithms/diffAlgo
             if (!valid && this.valid) {
                 this.valid = false; // timeout reached
                 // eslint-disable-next-line no-debugger
-                debugger; // WARNING: Most likely debugging caused the timeout. Call `this.disable()` to continue without timing out.
+                // debugger; // WARNING: Most likely debugging caused the timeout. Call `this.disable()` to continue without timing out.
             }
             return this.valid;
         }

--- a/src/main/resources/static/js/gw.process.util.js
+++ b/src/main/resources/static/js/gw.process.util.js
@@ -115,7 +115,7 @@ GW.process.util = {
             formatOnType: true,
             showFoldingControls: 'always',
             wordWrap: 'on',
-            scrollBeyondLastLine: true,
+            // scrollBeyondLastLine: true,
         });
         
         GW.process.editor = editor;
@@ -165,7 +165,7 @@ GW.process.util = {
           formatOnType: true,
           showFoldingControls: 'always',
           wordWrap: 'on',
-          scrollBeyondLastLine: true,
+          // scrollBeyondLastLine: true,
       });
 
       GW.process.editor = editor;


### PR DESCRIPTION
Removed Debugger from Monaco-workerMain(a loader file)
Also removed scrollbeyondLastLine to remove the excess empty space in the editor