### PR TITLE
added variable port 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,7 +48,7 @@ spring.datasource.hikari.auto-commit=true
 #spring.datasource.password=DFKHH9V6ME
 #spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-server.port=8070
+server.port=${GEOWEAVER_PORT:8070}
 
 # for test purpose
 #server.servlet.context-path=/api/


### PR DESCRIPTION
can change the port number by using export GEOWEAVER_PORT="add port number", then build 
example: export GEOWEAVER_PORT=8081

Just on running the app the url that is displayed is still 8070, so the port number in url is required to be manually changed