### PR TITLE
PostgreSQL

### DIFF
--- a/src/main/resources/application-postgresql.properties
+++ b/src/main/resources/application-postgresql.properties
@@ -1,0 +1,25 @@
+# PostgreSQL Configuration
+
+
+###########################################################################
+# Add the Database name, User name, password by removing the double quote. #
+###########################################################################
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/"add the name of DB"  #Eg: gw_db
+spring.datasource.username="add DB suername"  #Eg: gw_user
+spring.datasource.password="password"         #Eg: password
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+
+
+# Debugging properties (can be enabled if needed)
+# spring.jpa.show-sql=true
+# spring.jpa.properties.hibernate.format_sql=true
+# spring.jpa.properties.hibernate.use_sql_comments=true
+# logging.level.org.hibernate.type.descriptor.sql=trace
+
+
+
+spring.datasource.hikari.auto-commit=true


### PR DESCRIPTION
#### Added functionality to switch between H2 and PostgreSQL
Default is H2

- Command to run with H2: `java -jar target/geoweaver.jar`
- Command to run with PostgreSQL: `java -Dspring.profiles.active=postgresql -jar target/geoweaver.jar`


Create a new database in PostgreSQL and run the server then substitute the required fields in `application-postgresql.properties` file.

##### Required fields:

- DB name(url)
- Username
- Password

<img width="464" alt="Screenshot 2024-09-11 at 8 08 51 PM" src="https://github.com/user-attachments/assets/fe3538f8-1616-45a0-91c2-a745d474478e">


##### Commands for PostgreSQL:

- `sudo -i -u postgres`
- start server: `pg_ctl -D /path/to/the/PostgreSQL/data start`
- To interact with the Db: `psql -U username -d name_of_db -h localhost -p 5432` (The post can be changed, but then also change it in PostgreSQL Configuration)
- stop server: `pg_ctl -D /path/to/the/PostgreSQL/data stop`

