### PR TITLE
made notes column more readable

### DIFF
--- a/src/main/resources/static/js/gw.history.js
+++ b/src/main/resources/static/js/gw.history.js
@@ -436,7 +436,7 @@ GW.history = {
                   targets: [1],
                 },
                 {
-                    targets: [3],
+                    targets: '_all',
                     className: 'wrap-text'
                 }
             ],


### PR DESCRIPTION
<img width="956" alt="image" src="https://github.com/user-attachments/assets/fbce540c-5024-4548-87d2-949d2f287737">

Initially, the notes column was stacking up and not readable. Made a minor change by applying wrap-text class to all columns to avoid overflow issue and make notes column more readable.  Please test the functionality.