### PR TITLE
Display process name in the workflow history panel

### DIFF
--- a/src/main/resources/static/js/gw.workflow.js
+++ b/src/main/resources/static/js/gw.workflow.js
@@ -1149,12 +1149,14 @@ GW.workflow = {
     })
       .done(function (msg) {
         msg = $.parseJSON(msg);
+        nodes = GW.workspace.theGraph.nodes;
 
         var content =
           '<div class="modal-body" style="font-size: 12px;"><table class="table"> ' +
           "  <thead> " +
           "    <tr> " +
           '      <th scope="col">Process Id</th> ' +
+          '      <th scope="col">Process Name</th> ' +
           '      <th scope="col">History Id</th> ' +
           '      <th scope="col">Action</th> ' +
           "    </tr> " +
@@ -1166,6 +1168,9 @@ GW.workflow = {
             "    <tr> " +
             "      <td>" +
             msg.input[i] +
+            "</td> " +
+            "      <td>" +
+            nodes[i]['title'] +
             "</td> " +
             "      <td>" +
             msg.output[i] +


### PR DESCRIPTION
This PR resolves [issue_550](https://github.com/ESIPFed/Geoweaver/issues/550) of displaying process name in the workflow history panel table.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/182b9b87-fe60-4984-bf16-a6cb5a40ebbc">
