### PR TITLE
Use polling to replace the web socket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.gw</groupId>
 	<artifactId>geoweaver</artifactId>
-	<version>1.9.2</version>
+	<version>2.0.0</version>
 	<name>geoweaver</name>
 	<description>A lightweight workflow management software for organizing data analysis workflows, 
 	preserving history of every workflow run, and improving scientist producitvity and workflow FAIRness,

--- a/src/main/java/com/gw/server/CommandServlet.java
+++ b/src/main/java/com/gw/server/CommandServlet.java
@@ -48,9 +48,14 @@ public class CommandServlet {
     try {
       logger.debug("Command-socket WebSocket channel opened");
 
-      // You can register the session here for further tracking
-      // For example: this.registerSession(session);
+      // Store the session ID temporarily until we receive a token from the client
+      // The actual registration with a token happens in the echo method when a token message is received
+      logger.debug("WebSocket session opened with ID: " + session.getId());
+      
+      // We don't register the session here because we don't have a token yet
+      // The session will be registered when a token message is received in the echo method
     } catch (Exception e) {
+      logger.error("Error opening WebSocket connection: " + e.getMessage());
       e.printStackTrace();
     }
   }
@@ -63,11 +68,26 @@ public class CommandServlet {
    *     user.
    */
   public void registerSession(Session session, String token) {
+    if (session == null || token == null || token.isEmpty()) {
+      logger.warn("Cannot register null session or empty token");
+      return;
+    }
+    
     // Cast the session to a WsSession
     WsSession wss = (WsSession) session;
-
+    
+    // Log the registration for debugging
+    logger.debug("Registering WebSocket session for token: " + token);
+    
     // Associate the session with the user's token in the map
     peers.put(token, wss);
+    
+    // Verify registration was successful
+    if (peers.containsKey(token)) {
+      logger.debug("WebSocket session successfully registered for token: " + token);
+    } else {
+      logger.error("Failed to register WebSocket session for token: " + token);
+    }
   }
 
   /**
@@ -122,6 +142,19 @@ public class CommandServlet {
           logger.debug(" - Token: " + tokenfromclient);
           // Register the WebSocket session with the token
           this.registerSession(session, tokenfromclient);
+        }
+        // Check if the message starts with "execution:"
+        else if (message.startsWith("execution:")) {
+          // Extract the history ID from the message (substring from the 10th character)
+          String historyId = message.substring(10);
+          // Log the execution history ID for debugging
+          logger.debug(" - Execution History ID: " + historyId);
+          // Register the WebSocket session with the history ID
+          this.registerSession(session, historyId);
+          // Send confirmation message back to client
+          if (session.isOpen()) {
+            session.getBasicRemote().sendText(historyId + BaseTool.log_separator + "WebSocket session connected to execution: " + historyId);
+          }
         }
       }
 
@@ -236,36 +269,175 @@ public class CommandServlet {
    * @return The WebSocket session, or null if not found.
    */
   public static javax.websocket.Session findSessionById(String token) {
+    if (token == null || token.isEmpty()) {
+      logger.warn("Cannot find session with null or empty token");
+      return null;
+    }
+    
     javax.websocket.Session se = null;
     if (peers.containsKey(token)) {
       se = peers.get(token);
+      if (se == null) {
+        logger.warn("Session found in peers map for token '" + token + "' but is null");
+      }
+    } else {
+      logger.debug("No WebSocket session found for token: " + token);
     }
     return se;
   }
 
   /**
    * Sends a message to a specific WebSocket session identified by its token.
+   * Uses the configured default communication channel (WebSocket or HTTP long polling)
+   * based on the geoweaver.communication.default-channel property.
    *
    * @param token The token of the target WebSocket session.
    * @param message The message to be sent.
+   * @return The WebSocket session if successful via WebSocket, null if sent via long polling or failed.
    */
   public static Session sendMessageToSocket(String token, String message) {
-    try {
-      Session wsout = CommandServlet.findSessionById(token);
-      if (!BaseTool.isNull(wsout)) {
-        if (wsout.isOpen()) {
-          wsout.getBasicRemote().sendText(message);
-        } else {
-          CommandServlet.removeSessionById(token);
-        }
-      } else {
-        logger.warn(String.format("cannot find websocket for token %s", token));
-      }
-      return wsout;
-    } catch (IOException e1) {
-      e1.printStackTrace();
+    if (token == null || token.isEmpty() || message == null) {
+      logger.error("Cannot send message: token or message is null/empty");
+      return null;
     }
-    return null;
+    
+    boolean messageSent = false;
+    Session wsout = null;
+    String channelUsed = "none";
+    
+    // Get the communication config to determine which channel to try first
+    com.gw.utils.CommunicationConfig communicationConfig = null;
+    try {
+      communicationConfig = com.gw.utils.BeanTool.getBean(com.gw.utils.CommunicationConfig.class);
+    } catch (Exception e) {
+      logger.warn("Could not get CommunicationConfig bean, defaulting to WebSocket first");
+    }
+    
+    boolean tryWebSocketFirst = communicationConfig == null || communicationConfig.isWebSocketDefault();
+    
+    // Try the configured default channel first
+    if (tryWebSocketFirst) {
+      // Try WebSocket first
+      boolean webSocketSuccess = sendViaWebSocket(token, message);
+      if (webSocketSuccess) {
+        wsout = findSessionById(token);
+        messageSent = true;
+        channelUsed = "websocket";
+        logger.debug("Message sent successfully via WebSocket to token: " + token);
+      } else {
+        // Fallback to long polling
+        boolean longPollingSuccess = sendViaLongPolling(token, message);
+        if (longPollingSuccess) {
+          messageSent = true;
+          channelUsed = "longpolling";
+          logger.debug("Message sent successfully via long polling to token: " + token);
+        }
+      }
+    } else {
+      // Try long polling first
+      boolean longPollingSuccess = sendViaLongPolling(token, message);
+      if (longPollingSuccess) {
+        messageSent = true;
+        channelUsed = "longpolling";
+        logger.debug("Message sent successfully via long polling to token: " + token);
+      } else {
+        // Fallback to WebSocket
+        boolean webSocketSuccess = sendViaWebSocket(token, message);
+        if (webSocketSuccess) {
+          wsout = findSessionById(token);
+          messageSent = true;
+          channelUsed = "websocket";
+          logger.debug("Message sent successfully via WebSocket to token: " + token);
+        }
+      }
+    }
+    
+    if (!messageSent) {
+      logger.error("Failed to send message to token '" + token + "' via any communication channel");
+    }
+    
+    return wsout; // Only return non-null if WebSocket was used successfully
+  }
+  
+  /**
+   * Attempts to send a message via WebSocket.
+   * 
+   * @param token The client token
+   * @param message The message to send
+   * @return true if the message was sent successfully, false otherwise
+   */
+  private static boolean sendViaWebSocket(String token, String message) {
+    if (token == null || token.isEmpty() || message == null) {
+      logger.error("Cannot send WebSocket message: token or message is null/empty");
+      return false;
+    }
+    
+    try {
+      // Find the WebSocket session by token
+      Session wsout = CommandServlet.findSessionById(token);
+      
+      // Check if session exists
+      if (wsout == null) {
+        logger.warn("WebSocket session not found for token: " + token);
+        return false;
+      }
+      
+      // Check if session is open
+      if (!wsout.isOpen()) {
+        logger.warn("WebSocket session found but not open for token: " + token);
+        // Remove the closed session from the peers map
+        CommandServlet.removeSessionById(token);
+        return false;
+      }
+      
+      // Send the message
+      wsout.getBasicRemote().sendText(message);
+      logger.debug("Message sent via WebSocket to token: " + token);
+      return true;
+      
+    } catch (IOException e) {
+      logger.error("WebSocket communication error for token '" + token + "': " + e.getMessage());
+      e.printStackTrace();
+      return false;
+    }
+  }
+  
+  /**
+   * Attempts to send a message via HTTP long polling.
+   * 
+   * @param token The client token
+   * @param message The message to send
+   * @return true if the message was sent successfully, false otherwise
+   */
+  private static boolean sendViaLongPolling(String token, String message) {
+    if (token == null || token.isEmpty() || message == null) {
+      logger.error("Cannot send long polling message: token or message is null/empty");
+      return false;
+    }
+    
+    try {
+      // Get the LongPollingController bean from Spring context
+      LongPollingController longPollingController = 
+          com.gw.utils.BeanTool.getBean(LongPollingController.class);
+      
+      if (longPollingController == null) {
+        logger.error("Could not get LongPollingController bean");
+        return false;
+      }
+      
+      boolean sent = longPollingController.sendMessageToClient(token, message);
+      if (sent) {
+        logger.debug("Message sent via long polling to token: " + token);
+        return true;
+      } else {
+        logger.error("Failed to send message via long polling to token: " + token);
+        return false;
+      }
+    } catch (Exception e) {
+      logger.error("Error using long polling for token '" + token + "': " + e.getMessage());
+      e.printStackTrace();
+      return false;
+    }
   }
 
   /**
@@ -274,7 +446,19 @@ public class CommandServlet {
    * @param token The token of the WebSocket session to be removed.
    */
   public static void removeSessionById(String token) {
+    if (token == null || token.isEmpty()) {
+      logger.warn("Cannot remove session with null or empty token");
+      return;
+    }
+    
+    boolean existed = peers.containsKey(token);
     peers.remove(token);
+    
+    if (existed) {
+      logger.debug("WebSocket session removed for token: " + token);
+    } else {
+      logger.debug("No WebSocket session found to remove for token: " + token);
+    }
   }
 
   /** Clears all WebSocket sessions from the peers map. */

--- a/src/main/java/com/gw/server/LongPollingController.java
+++ b/src/main/java/com/gw/server/LongPollingController.java
@@ -1,0 +1,136 @@
+package com.gw.server;
+
+import com.gw.utils.BaseTool;
+import com.gw.utils.MessageQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Controller for HTTP long polling as a fallback when WebSocket connections fail.
+ * This provides an alternative communication channel for clients that cannot establish
+ * or maintain WebSocket connections (e.g., due to proxy issues).
+ */
+@RestController
+@RequestMapping("/api/longpoll")
+public class LongPollingController {
+
+    private static final Logger logger = LoggerFactory.getLogger(LongPollingController.class);
+    
+    @Autowired
+    private MessageQueue messageQueue;
+    
+    // Map to store pending requests
+    private final Map<String, DeferredResult<ResponseEntity<?>>> pendingRequests = new ConcurrentHashMap<>();
+    
+    // Timeout for long polling requests (in milliseconds)
+    private static final long LONG_POLL_TIMEOUT = 30000; // 30 seconds
+    
+    /**
+     * Endpoint for clients to poll for messages.
+     * If messages are available, they are returned immediately.
+     * If no messages are available, the request is held until messages arrive or timeout occurs.
+     * 
+     * @param token The client token
+     * @return DeferredResult containing messages or timeout status
+     */
+    @GetMapping("/poll/{token}")
+    public DeferredResult<ResponseEntity<?>> pollMessages(@PathVariable String token) {
+        logger.debug("Received long polling request for token: {}", token);
+        
+        DeferredResult<ResponseEntity<?>> result = new DeferredResult<>(LONG_POLL_TIMEOUT);
+        
+        // Check if there are already messages in the queue
+        if (messageQueue.hasMessages(token)) {
+            String[] messages = messageQueue.getAndClearMessages(token);
+            result.setResult(ResponseEntity.ok(messages));
+            return result;
+        }
+        
+        // Store the pending request
+        pendingRequests.put(token, result);
+        
+        // Set timeout callback
+        result.onTimeout(() -> {
+            pendingRequests.remove(token);
+            result.setResult(ResponseEntity.status(HttpStatus.NO_CONTENT).body(null));
+            logger.debug("Long polling request timed out for token: {}", token);
+        });
+        
+        // Set completion callback to clean up resources
+        result.onCompletion(() -> {
+            pendingRequests.remove(token);
+        });
+        
+        return result;
+    }
+    
+    /**
+     * Endpoint for sending messages to clients.
+     * This is used internally by the system to send messages to clients via long polling.
+     * 
+     * @param token The client token
+     * @param message The message to send
+     * @return Status of the operation
+     */
+    @PostMapping("/send/{token}")
+    public ResponseEntity<?> sendMessage(
+            @PathVariable String token, 
+            @RequestBody String message) {
+        
+        logger.debug("Sending message to token: {}", token);
+        
+        // Check if there's a pending request for this token
+        DeferredResult<ResponseEntity<?>> pendingRequest = pendingRequests.remove(token);
+        
+        if (pendingRequest != null && !pendingRequest.isSetOrExpired()) {
+            // If there's a pending request, complete it with the message
+            pendingRequest.setResult(ResponseEntity.ok(new String[]{message}));
+            return ResponseEntity.ok().build();
+        } else {
+            // Otherwise, queue the message for future polling
+            boolean added = messageQueue.addMessage(token, message);
+            if (added) {
+                return ResponseEntity.ok().build();
+            } else {
+                return ResponseEntity.status(HttpStatus.INSUFFICIENT_STORAGE)
+                        .body("Failed to queue message: queue full or other error");
+            }
+        }
+    }
+    
+    /**
+     * Utility method to send a message to a client via long polling.
+     * This is used by other components to send messages when WebSocket is unavailable.
+     * 
+     * @param token The client token
+     * @param message The message to send
+     * @return true if the message was sent or queued successfully, false otherwise
+     */
+    public boolean sendMessageToClient(String token, String message) {
+        if (BaseTool.isNull(token) || BaseTool.isNull(message)) {
+            logger.warn("Attempted to send null token or message");
+            return false;
+        }
+        
+        // Check if there's a pending request for this token
+        DeferredResult<ResponseEntity<?>> pendingRequest = pendingRequests.remove(token);
+        
+        if (pendingRequest != null && !pendingRequest.isSetOrExpired()) {
+            // If there's a pending request, complete it with the message
+            pendingRequest.setResult(ResponseEntity.ok(new String[]{message}));
+            return true;
+        } else {
+            // Otherwise, queue the message for future polling
+            return messageQueue.addMessage(token, message);
+        }
+    }
+}

--- a/src/main/java/com/gw/server/WorkflowServlet.java
+++ b/src/main/java/com/gw/server/WorkflowServlet.java
@@ -1,5 +1,6 @@
 package com.gw.server;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.websocket.EndpointConfig;
@@ -11,6 +12,9 @@ import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 import org.apache.log4j.Logger;
 import org.apache.tomcat.websocket.WsSession;
+import com.gw.utils.BaseTool;
+import com.gw.utils.BeanTool;
+import com.gw.utils.CommunicationConfig;
 
 /**
  * This class is used for monitoring workflow execution
@@ -135,11 +139,192 @@ public class WorkflowServlet {
     }
   }
 
+  /**
+   * Finds a WebSocket session by its token.
+   *
+   * @param token The token used to identify the WebSocket session.
+   * @return The WebSocket session, or null if not found.
+   */
   public static javax.websocket.Session findSessionByToken(String token) {
     javax.websocket.Session se = null;
-    if (peers.containsKey(token)) {
+    if (token != null && peers.containsKey(token)) {
       se = peers.get(token);
     }
     return se;
+  }
+  
+  /**
+   * Sends a message to a specific WebSocket session identified by its token.
+   * Uses the configured default communication channel (WebSocket or HTTP long polling)
+   * based on the geoweaver.communication.default-channel property.
+   *
+   * @param token The token of the target WebSocket session.
+   * @param message The message to be sent.
+   * @return The WebSocket session if successful via WebSocket, null if sent via long polling or failed.
+   */
+  public static Session sendMessageToSocket(String token, String message) {
+    if (token == null || token.isEmpty() || message == null) {
+      Logger.getLogger(WorkflowServlet.class).error("Cannot send message: token or message is null/empty");
+      return null;
+    }
+    
+    boolean messageSent = false;
+    Session wsout = null;
+    String channelUsed = "none";
+    
+    // Get the communication config to determine which channel to try first
+    CommunicationConfig communicationConfig = null;
+    try {
+      communicationConfig = BeanTool.getBean(CommunicationConfig.class);
+    } catch (Exception e) {
+      Logger.getLogger(WorkflowServlet.class).warn("Could not get CommunicationConfig bean, defaulting to WebSocket first");
+    }
+    
+    boolean tryWebSocketFirst = communicationConfig == null || communicationConfig.isWebSocketDefault();
+    
+    // Try the configured default channel first
+    if (tryWebSocketFirst) {
+      // Try WebSocket first
+      boolean webSocketSuccess = sendViaWebSocket(token, message);
+      if (webSocketSuccess) {
+        wsout = findSessionByToken(token);
+        messageSent = true;
+        channelUsed = "websocket";
+        Logger.getLogger(WorkflowServlet.class).debug("Message sent successfully via WebSocket to token: " + token);
+      } else {
+        // Fallback to long polling
+        boolean longPollingSuccess = sendViaLongPolling(token, message);
+        if (longPollingSuccess) {
+          messageSent = true;
+          channelUsed = "longpolling";
+          Logger.getLogger(WorkflowServlet.class).debug("Message sent successfully via long polling to token: " + token);
+        }
+      }
+    } else {
+      // Try long polling first
+      boolean longPollingSuccess = sendViaLongPolling(token, message);
+      if (longPollingSuccess) {
+        messageSent = true;
+        channelUsed = "longpolling";
+        Logger.getLogger(WorkflowServlet.class).debug("Message sent successfully via long polling to token: " + token);
+      } else {
+        // Fallback to WebSocket
+        boolean webSocketSuccess = sendViaWebSocket(token, message);
+        if (webSocketSuccess) {
+          wsout = findSessionByToken(token);
+          messageSent = true;
+          channelUsed = "websocket";
+          Logger.getLogger(WorkflowServlet.class).debug("Message sent successfully via WebSocket to token: " + token);
+        }
+      }
+    }
+    
+    if (!messageSent) {
+      Logger.getLogger(WorkflowServlet.class).error("Failed to send message to token '" + token + "' via any communication channel");
+    }
+    
+    return wsout; // Only return non-null if WebSocket was used successfully
+  }
+  
+  /**
+   * Attempts to send a message via WebSocket.
+   * 
+   * @param token The client token
+   * @param message The message to send
+   * @return true if the message was sent successfully, false otherwise
+   */
+  private static boolean sendViaWebSocket(String token, String message) {
+    if (token == null || token.isEmpty() || message == null) {
+      Logger.getLogger(WorkflowServlet.class).error("Cannot send WebSocket message: token or message is null/empty");
+      return false;
+    }
+    
+    try {
+      // Find the WebSocket session by token
+      Session wsout = WorkflowServlet.findSessionByToken(token);
+      
+      // Check if session exists
+      if (wsout == null) {
+        Logger.getLogger(WorkflowServlet.class).warn("WebSocket session not found for token: " + token);
+        return false;
+      }
+      
+      // Check if session is open
+      if (!wsout.isOpen()) {
+        Logger.getLogger(WorkflowServlet.class).warn("WebSocket session found but not open for token: " + token);
+        // Remove the closed session from the peers map
+        WorkflowServlet.removeSessionById(token);
+        return false;
+      }
+      
+      // Send the message
+      wsout.getBasicRemote().sendText(message);
+      Logger.getLogger(WorkflowServlet.class).debug("Message sent via WebSocket to token: " + token);
+      return true;
+      
+    } catch (IOException e) {
+      Logger.getLogger(WorkflowServlet.class).error("WebSocket communication error for token '" + token + "': " + e.getMessage());
+      e.printStackTrace();
+      return false;
+    }
+  }
+  
+  /**
+   * Attempts to send a message via HTTP long polling.
+   * 
+   * @param token The client token
+   * @param message The message to send
+   * @return true if the message was sent successfully, false otherwise
+   */
+  private static boolean sendViaLongPolling(String token, String message) {
+    if (token == null || token.isEmpty() || message == null) {
+      Logger.getLogger(WorkflowServlet.class).error("Cannot send long polling message: token or message is null/empty");
+      return false;
+    }
+    
+    try {
+      // Get the LongPollingController bean from Spring context
+      LongPollingController longPollingController = 
+          BeanTool.getBean(LongPollingController.class);
+      
+      if (longPollingController == null) {
+        Logger.getLogger(WorkflowServlet.class).error("Could not get LongPollingController bean");
+        return false;
+      }
+      
+      boolean sent = longPollingController.sendMessageToClient(token, message);
+      if (sent) {
+        Logger.getLogger(WorkflowServlet.class).debug("Message sent via long polling to token: " + token);
+        return true;
+      } else {
+        Logger.getLogger(WorkflowServlet.class).error("Failed to send message via long polling to token: " + token);
+        return false;
+      }
+    } catch (Exception e) {
+      Logger.getLogger(WorkflowServlet.class).error("Error using long polling for token '" + token + "': " + e.getMessage());
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  /**
+   * Removes a WebSocket session from the peers map based on its token.
+   *
+   * @param token The token of the WebSocket session to be removed.
+   */
+  public static void removeSessionById(String token) {
+    if (token == null || token.isEmpty()) {
+      Logger.getLogger(WorkflowServlet.class).warn("Cannot remove session with null or empty token");
+      return;
+    }
+    
+    boolean existed = peers.containsKey(token);
+    peers.remove(token);
+    
+    if (existed) {
+      Logger.getLogger(WorkflowServlet.class).debug("WebSocket session removed for token: " + token);
+    } else {
+      Logger.getLogger(WorkflowServlet.class).debug("No WebSocket session found to remove for token: " + token);
+    }
   }
 }

--- a/src/main/java/com/gw/tasks/GeoweaverProcessTask.java
+++ b/src/main/java/com/gw/tasks/GeoweaverProcessTask.java
@@ -578,17 +578,20 @@ public class GeoweaverProcessTask extends Task {
 
   }
 
+  /**
+   * Sends a message to the workflow WebSocket or long polling channel based on the configured default channel.
+   * Uses the WorkflowServlet's sendMessageToSocket method which handles the channel selection and fallback.
+   *
+   * @param msg The message to send
+   */
   void sendMessage2WorkflowWebsocket(String msg) {
-
-    if (workflow_monitor != null) {
-
-      synchronized (workflow_monitor) {
-        try {
-          workflow_monitor.getBasicRemote().sendText(msg);
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
+    try {
+      // Use the WorkflowServlet's sendMessageToSocket method which handles channel selection
+      // This will automatically use the configured default channel (WebSocket or long polling)
+      WorkflowServlet.sendMessageToSocket(token, msg);
+    } catch (Exception e) {
+      logger.error("Error sending workflow message: " + e.getMessage());
+      e.printStackTrace();
     }
   }
 

--- a/src/main/java/com/gw/tasks/GeoweaverWorkflowTask.java
+++ b/src/main/java/com/gw/tasks/GeoweaverWorkflowTask.java
@@ -192,31 +192,30 @@ public class GeoweaverWorkflowTask {
 
       refreshMonitor();
 
-      if (monitor != null) {
+      JSONArray array = new JSONArray();
 
-        JSONArray array = new JSONArray();
+      for (int i = 0; i < nodes.size(); i++) {
 
-        for (int i = 0; i < nodes.size(); i++) {
+        String id = (String) ((JSONObject) nodes.get(i)).get("id");
 
-          String id = (String) ((JSONObject) nodes.get(i)).get("id");
+        String history_id = (String) ((JSONObject) nodes.get(i)).get("history_id");
 
-          String history_id = (String) ((JSONObject) nodes.get(i)).get("history_id");
+        JSONObject obj = new JSONObject();
 
-          JSONObject obj = new JSONObject();
+        obj.put("id", id);
 
-          obj.put("id", id);
+        obj.put("history_id", history_id);
 
-          obj.put("history_id", history_id);
+        obj.put("status", flags[i].toString());
 
-          obj.put("status", flags[i].toString());
-
-          array.add(obj);
-        }
-
-        log.debug("Send workflow process status back to the client: " + array);
-
-        monitor.getBasicRemote().sendText(array.toJSONString());
+        array.add(obj);
       }
+
+      log.debug("Send workflow process status back to the client: " + array);
+
+      // Use the WorkflowServlet's sendMessageToSocket method which handles channel selection
+      // This will automatically use the configured default channel (WebSocket or long polling)
+      WorkflowServlet.sendMessageToSocket(token, array.toJSONString());
 
     } catch (Exception e) {
 
@@ -230,19 +229,19 @@ public class GeoweaverWorkflowTask {
     try {
       log.info("close the websocket session from server side");
 
-      if (!BaseTool.isNull(monitor))
-        monitor
-            .getBasicRemote()
-            .sendText(
-                "{\"workflow_status\": \"completed\", \"workflow_history_id\":\""
-                    + this.history_id
-                    + "\"}");
+      // Use the WorkflowServlet's sendMessageToSocket method which handles channel selection
+      // This will automatically use the configured default channel (WebSocket or long polling)
+      WorkflowServlet.sendMessageToSocket(
+          token,
+          "{\"workflow_status\": \"completed\", \"workflow_history_id\":\""
+              + this.history_id
+              + "\"}");
       // if(!BaseTool.isNull(monitor))
       // 	monitor.close();
 
       // wt.token2ws.remove(token);
 
-    } catch (IOException e) {
+    } catch (Exception e) {
 
       e.printStackTrace();
     }

--- a/src/main/java/com/gw/utils/CommunicationConfig.java
+++ b/src/main/java/com/gw/utils/CommunicationConfig.java
@@ -1,0 +1,51 @@
+package com.gw.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for Geoweaver communication settings.
+ * This class manages the configuration for communication channels between client and server.
+ */
+@Configuration
+public class CommunicationConfig {
+    
+    private static final Logger logger = LoggerFactory.getLogger(CommunicationConfig.class);
+    
+    /**
+     * The default communication channel to use.
+     * Possible values: "websocket" (default) or "polling"
+     */
+    @Value("${geoweaver.communication.default-channel:websocket}")
+    private String defaultChannel;
+    
+    /**
+     * Get the configured default communication channel.
+     * 
+     * @return The default communication channel ("websocket" or "polling")
+     */
+    public String getDefaultChannel() {
+        logger.debug("Using communication channel: {}", defaultChannel);
+        return defaultChannel;
+    }
+    
+    /**
+     * Check if WebSocket is the default communication channel.
+     * 
+     * @return true if WebSocket is the default, false otherwise
+     */
+    public boolean isWebSocketDefault() {
+        return "websocket".equalsIgnoreCase(defaultChannel);
+    }
+    
+    /**
+     * Check if HTTP long polling is the default communication channel.
+     * 
+     * @return true if polling is the default, false otherwise
+     */
+    public boolean isPollingDefault() {
+        return "polling".equalsIgnoreCase(defaultChannel);
+    }
+}

--- a/src/main/java/com/gw/utils/CommunicationConfig.java
+++ b/src/main/java/com/gw/utils/CommunicationConfig.java
@@ -16,9 +16,9 @@ public class CommunicationConfig {
     
     /**
      * The default communication channel to use.
-     * Possible values: "websocket" (default) or "polling"
+     * Possible values: "websocket" or "polling" (default)
      */
-    @Value("${geoweaver.communication.default-channel:websocket}")
+    @Value("${geoweaver.communication.default-channel:polling}")
     private String defaultChannel;
     
     /**

--- a/src/main/java/com/gw/utils/MessageQueue.java
+++ b/src/main/java/com/gw/utils/MessageQueue.java
@@ -1,0 +1,137 @@
+package com.gw.utils;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * A message queue for storing messages when WebSocket is unavailable.
+ * This provides a fallback mechanism for communication when WebSocket connections fail.
+ */
+@Component
+public class MessageQueue {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageQueue.class);
+    
+    // Map of token to queue of messages
+    private final Map<String, Queue<String>> messageQueues = new ConcurrentHashMap<>();
+    
+    // Maximum number of messages to store per token
+    private static final int MAX_QUEUE_SIZE = 1000;
+    
+    /**
+     * Add a message to the queue for a specific token.
+     * 
+     * @param token The token identifying the client
+     * @param message The message to queue
+     * @return true if the message was added, false if the queue is full
+     */
+    public boolean addMessage(String token, String message) {
+        if (token == null || message == null) {
+            logger.warn("Attempted to add null token or message to queue");
+            return false;
+        }
+        
+        Queue<String> queue = messageQueues.computeIfAbsent(token, k -> new ConcurrentLinkedQueue<>());
+        
+        // Check if queue has reached maximum size
+        if (queue.size() >= MAX_QUEUE_SIZE) {
+            logger.warn("Message queue for token {} is full", token);
+            return false;
+        }
+        
+        return queue.offer(message);
+    }
+    
+    /**
+     * Get and remove all messages for a specific token.
+     * 
+     * @param token The token identifying the client
+     * @return Array of messages, or empty array if no messages
+     */
+    public String[] getAndClearMessages(String token) {
+        if (token == null) {
+            logger.warn("Attempted to get messages for null token");
+            return new String[0];
+        }
+        
+        Queue<String> queue = messageQueues.get(token);
+        if (queue == null || queue.isEmpty()) {
+            return new String[0];
+        }
+        
+        String[] messages = queue.toArray(new String[0]);
+        queue.clear();
+        return messages;
+    }
+    
+    /**
+     * Get all messages for a specific token without removing them.
+     * 
+     * @param token The token identifying the client
+     * @return Array of messages, or empty array if no messages
+     */
+    public String[] peekMessages(String token) {
+        if (token == null) {
+            logger.warn("Attempted to peek messages for null token");
+            return new String[0];
+        }
+        
+        Queue<String> queue = messageQueues.get(token);
+        if (queue == null || queue.isEmpty()) {
+            return new String[0];
+        }
+        
+        return queue.toArray(new String[0]);
+    }
+    
+    /**
+     * Check if there are any messages for a specific token.
+     * 
+     * @param token The token identifying the client
+     * @return true if there are messages, false otherwise
+     */
+    public boolean hasMessages(String token) {
+        if (token == null) {
+            return false;
+        }
+        
+        Queue<String> queue = messageQueues.get(token);
+        return queue != null && !queue.isEmpty();
+    }
+    
+    /**
+     * Clear all messages for a specific token.
+     * 
+     * @param token The token identifying the client
+     */
+    public void clearMessages(String token) {
+        if (token == null) {
+            return;
+        }
+        
+        Queue<String> queue = messageQueues.get(token);
+        if (queue != null) {
+            queue.clear();
+        }
+    }
+    
+    /**
+     * Get the number of messages for a specific token.
+     * 
+     * @param token The token identifying the client
+     * @return Number of messages
+     */
+    public int getMessageCount(String token) {
+        if (token == null) {
+            return 0;
+        }
+        
+        Queue<String> queue = messageQueues.get(token);
+        return queue != null ? queue.size() : 0;
+    }
+}

--- a/src/main/java/com/gw/web/CommunicationConfigController.java
+++ b/src/main/java/com/gw/web/CommunicationConfigController.java
@@ -1,0 +1,35 @@
+package com.gw.web;
+
+import com.gw.utils.CommunicationConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * REST controller for exposing communication configuration to clients.
+ * This allows clients to query the server's preferred communication channel.
+ */
+@RestController
+@RequestMapping("/api/config")
+public class CommunicationConfigController {
+
+    @Autowired
+    private CommunicationConfig communicationConfig;
+    
+    /**
+     * Get the server's preferred communication channel.
+     * 
+     * @return JSON response with the default channel configuration
+     */
+    @GetMapping("/communication-channel")
+    public ResponseEntity<Map<String, String>> getCommunicationChannel() {
+        Map<String, String> response = new HashMap<>();
+        response.put("defaultChannel", communicationConfig.getDefaultChannel());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -101,6 +101,6 @@ geoweaver.follow_symlinks=true
 # Possible values: 'websocket' (default) or 'polling'
 # websocket: Use WebSocket as primary communication channel with HTTP long polling as fallback
 # polling: Use HTTP long polling as primary communication channel with WebSocket as fallback
-geoweaver.communication.default-channel=websocket
+geoweaver.communication.default-channel=polling
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -97,4 +97,10 @@ geoweaver.allowed_ssh_clients=*
 geoweaver.secret_properties_path=cc_secret.properties
 geoweaver.follow_symlinks=true
 
+# Communication channel configuration
+# Possible values: 'websocket' (default) or 'polling'
+# websocket: Use WebSocket as primary communication channel with HTTP long polling as fallback
+# polling: Use HTTP long polling as primary communication channel with WebSocket as fallback
+geoweaver.communication.default-channel=websocket
+
 

--- a/src/main/resources/static/js/gw.communication.js
+++ b/src/main/resources/static/js/gw.communication.js
@@ -1,0 +1,282 @@
+/**
+ * Communication module for Geoweaver
+ * 
+ * Provides a unified interface for communication between client and server
+ * with automatic fallback from WebSocket to HTTP long polling when WebSocket
+ * connections fail (e.g., due to proxy issues).
+ */
+
+GW.communication = {
+    // WebSocket connection
+    ws: null,
+    
+    // Token for identifying the client
+    token: null,
+    
+    // Flag to track if we're using the fallback mechanism
+    usingFallback: false,
+    
+    // Polling interval in milliseconds
+    pollingInterval: 1000,
+    
+    // Flag to track if polling is active
+    isPolling: false,
+    
+    // Callback for handling messages
+    messageHandler: null,
+    
+    // Flag to track connection status
+    isConnected: false,
+    
+    /**
+     * Initialize the communication module
+     * 
+     * @param {string} token - The client token
+     * @param {function} messageHandler - Callback for handling messages
+     */
+    init: function(token, messageHandler) {
+        this.token = token;
+        this.messageHandler = messageHandler;
+        
+        // Check server's preferred communication channel
+        this.checkServerPreference();
+    },
+    
+    /**
+     * Check the server's preferred communication channel
+     * This queries the server for its configuration setting
+     */
+    checkServerPreference: function() {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", "/Geoweaver/api/config/communication-channel", true);
+        xhr.timeout = 5000;
+        
+        xhr.onload = function() {
+            if (xhr.status === 200) {
+                try {
+                    var response = JSON.parse(xhr.responseText);
+                    if (response && response.defaultChannel) {
+                        // If server prefers polling, start with that
+                        if (response.defaultChannel === "polling") {
+                            console.log("Server prefers HTTP long polling, starting with that");
+                            GW.communication.usingFallback = true;
+                            GW.communication.startPolling();
+                        } else {
+                            // Otherwise use WebSocket (default)
+                            console.log("Server prefers WebSocket, starting with that");
+                            GW.communication.connect();
+                        }
+                    } else {
+                        // Default to WebSocket if response is invalid
+                        GW.communication.connect();
+                    }
+                } catch (error) {
+                    console.error("Error parsing server preference:", error);
+                    GW.communication.connect();
+                }
+            } else {
+                // Default to WebSocket if request fails
+                GW.communication.connect();
+            }
+        };
+        
+        xhr.onerror = function() {
+            console.error("Error checking server preference");
+            GW.communication.connect();
+        };
+        
+        xhr.ontimeout = function() {
+            console.error("Timeout checking server preference");
+            GW.communication.connect();
+        };
+        
+        xhr.send();
+    },
+    
+    /**
+     * Connect to the server using WebSocket
+     * Falls back to long polling if WebSocket connection fails
+     */
+    connect: function() {
+        // Reset connection status
+        this.isConnected = false;
+        this.usingFallback = false;
+        
+        try {
+            // Get WebSocket URL prefix
+            var wsPrefix = (window.location.protocol === "https:" ? "wss://" : "ws://") + 
+                          window.location.host + "/Geoweaver/";
+            
+            // Create WebSocket connection
+            this.ws = new WebSocket(wsPrefix + "command-socket");
+            
+            // Set up WebSocket event handlers
+            this.ws.onopen = function(e) {
+                console.log("WebSocket connection established");
+                GW.communication.isConnected = true;
+                
+                // Send token to register the session
+                setTimeout(function() {
+                    GW.communication.send("token:" + GW.communication.token);
+                }, 1000);
+            };
+            
+            this.ws.onclose = function(e) {
+                console.log("WebSocket connection closed");
+                GW.communication.isConnected = false;
+                
+                // Switch to fallback if not already using it
+                if (!GW.communication.usingFallback) {
+                    console.log("Switching to long polling fallback");
+                    GW.communication.usingFallback = true;
+                    GW.communication.startPolling();
+                }
+            };
+            
+            this.ws.onerror = function(e) {
+                console.error("WebSocket error:", e);
+                GW.communication.isConnected = false;
+                
+                // Switch to fallback if not already using it
+                if (!GW.communication.usingFallback) {
+                    console.log("WebSocket error, switching to long polling fallback");
+                    GW.communication.usingFallback = true;
+                    GW.communication.startPolling();
+                }
+            };
+            
+            this.ws.onmessage = function(e) {
+                // Handle incoming WebSocket messages
+                if (GW.communication.messageHandler) {
+                    GW.communication.messageHandler(e.data);
+                }
+            };
+        } catch (error) {
+            console.error("Error creating WebSocket connection:", error);
+            
+            // Switch to fallback
+            this.usingFallback = true;
+            this.startPolling();
+        }
+    },
+    
+    /**
+     * Start long polling for messages
+     */
+    startPolling: function() {
+        if (this.isPolling) {
+            return; // Already polling
+        }
+        
+        this.isPolling = true;
+        this.poll();
+    },
+    
+    /**
+     * Stop long polling
+     */
+    stopPolling: function() {
+        this.isPolling = false;
+    },
+    
+    /**
+     * Poll for messages using long polling
+     */
+    poll: function() {
+        if (!this.isPolling) {
+            return; // Polling has been stopped
+        }
+        
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", "/Geoweaver/api/longpoll/poll/" + this.token, true);
+        xhr.timeout = 35000; // Slightly longer than server timeout
+        
+        xhr.onload = function() {
+            if (xhr.status === 200) {
+                // Process messages
+                try {
+                    var messages = JSON.parse(xhr.responseText);
+                    if (messages && messages.length > 0) {
+                        for (var i = 0; i < messages.length; i++) {
+                            if (GW.communication.messageHandler) {
+                                GW.communication.messageHandler(messages[i]);
+                            }
+                        }
+                    }
+                } catch (error) {
+                    console.error("Error parsing long polling response:", error);
+                }
+            }
+            
+            // Continue polling
+            setTimeout(function() {
+                GW.communication.poll();
+            }, 100); // Small delay before next poll
+        };
+        
+        xhr.onerror = function() {
+            console.error("Long polling request failed");
+            
+            // Retry after delay
+            setTimeout(function() {
+                GW.communication.poll();
+            }, GW.communication.pollingInterval);
+        };
+        
+        xhr.ontimeout = function() {
+            // This is normal for long polling - just start a new request
+            GW.communication.poll();
+        };
+        
+        xhr.send();
+    },
+    
+    /**
+     * Send a message to the server
+     * Uses WebSocket if available, falls back to HTTP POST if not
+     * 
+     * @param {string} message - The message to send
+     */
+    send: function(message) {
+        if (!this.usingFallback && this.ws && this.ws.readyState === WebSocket.OPEN) {
+            // Use WebSocket
+            this.ws.send(message);
+        } else {
+            // Use HTTP POST fallback
+            var xhr = new XMLHttpRequest();
+            xhr.open("POST", "/Geoweaver/api/longpoll/send/" + this.token, true);
+            xhr.setRequestHeader("Content-Type", "text/plain");
+            xhr.send(message);
+        }
+    },
+    
+    /**
+     * Check connection status and reconnect if needed
+     */
+    checkConnection: function() {
+        if (!this.usingFallback && (!this.ws || this.ws.readyState === WebSocket.CLOSED)) {
+            console.log("Connection check: WebSocket is closed, reconnecting...");
+            this.connect();
+        }
+    },
+    
+    /**
+     * Close the connection
+     */
+    close: function() {
+        // Stop polling
+        this.stopPolling();
+        
+        // Close WebSocket if open
+        if (this.ws) {
+            try {
+                this.ws.close();
+            } catch (error) {
+                console.error("Error closing WebSocket:", error);
+            }
+            this.ws = null;
+        }
+        
+        this.isConnected = false;
+    }
+};

--- a/src/main/resources/static/js/gw.js
+++ b/src/main/resources/static/js/gw.js
@@ -9,7 +9,7 @@ edu = {
         sponsor:
           "ESIPLab incubator project, NASA ACCESS project, NSF Geoinformatics project, NSF Cybertraining project",
 
-        version: "1.9.2",
+        version: "2.0.0",
 
         author: "open source contributors",
 

--- a/src/main/resources/static/js/gw.main.js
+++ b/src/main/resources/static/js/gw.main.js
@@ -101,13 +101,13 @@ GW.main = {
 
     // console.log("Current JS Session ID: " + current_jssessionid);
 
-    var current_token = GW.general.makeid(40); // this is no longer used
+    // var current_token = GW.general.makeid(40); // this is no longer used
 
-    console.log("Current token is: " + current_token);
+    // console.log("Current token is: " + current_token);
 
-    GW.ssh.startLogSocket(current_token);
+    GW.ssh.startLogSocket(GW.general.CLIENT_TOKEN);
 
-    GW.monitor.startSocket(current_token); //this token will be saved as GW.monitor.token and can be used everywhere
+    GW.monitor.startSocket(GW.general.CLIENT_TOKEN); //this token will be saved as GW.monitor.token and can be used everywhere
 
     GW.board.init();
 

--- a/src/main/resources/static/js/gw.ssh.js
+++ b/src/main/resources/static/js/gw.ssh.js
@@ -77,16 +77,10 @@ GW.ssh = {
 
           console.log(returnmsg);
 
-          if (returnmsg.ret == "success") {
-            setTimeout(function () {
-              GW.process.callback(returnmsg);
-            }, 2000);
-          }
-
           if (returnmsg.builtin) {
             GW.process.callback(returnmsg);
           } else {
-            // GW.workspace.updateStatus(returnmsg); // the workflow status message should only come from the workflow-socket
+            GW.workspace.updateStatus(returnmsg); 
           }
         } catch (errors) {
           console.error(errors);

--- a/src/main/resources/static/js/gw.ssh.js
+++ b/src/main/resources/static/js/gw.ssh.js
@@ -216,7 +216,7 @@ GW.ssh = {
       $(".dot-flashing").removeClass("visible").addClass("invisible");
     } else if (log_history_id == GW.process.history_id) {
       // This log belongs to the current process
-      style1 = "color: green;";
+      style1 = "color: black;";
       $(".dot-flashing").removeClass("invisible").addClass("visible");
     } else {
       $(".dot-flashing").removeClass("visible").addClass("invisible");

--- a/src/main/resources/static/js/gw.ssh.js
+++ b/src/main/resources/static/js/gw.ssh.js
@@ -80,7 +80,11 @@ GW.ssh = {
           if (returnmsg.builtin) {
             GW.process.callback(returnmsg);
           } else {
-            GW.workspace.updateStatus(returnmsg); 
+            if (returnmsg.workflow_status == "completed") {
+              GW.monitor.stopMonitor();
+            } else {
+              GW.workspace.updateStatus(returnmsg);
+            }
           }
         } catch (errors) {
           console.error(errors);
@@ -294,7 +298,7 @@ GW.ssh = {
         message.indexOf(GW.ssh.special.ready) == -1 &&
         message.indexOf("No SSH connection is active") == -1
       ) {
-        GW.ssh.echo(message);
+        GW.ssh.echo(message); // this function will be used to process all polling responses
       }
     });
     

--- a/src/main/resources/static/js/gw.ssh.js
+++ b/src/main/resources/static/js/gw.ssh.js
@@ -103,7 +103,9 @@ GW.ssh = {
 
   send: function (data) {
     if (this.ws != null) {
-      this.ws.send(data);
+      // Use the communication module to send data
+      // This will automatically use WebSocket or HTTP fallback as appropriate
+      GW.communication.send(data);
     } else {
       if (data != this.token) {
         this.error("not connected!");
@@ -191,38 +193,38 @@ GW.ssh = {
     var dt = new Date();
     var time = dt.getHours() + ":" + dt.getMinutes() + ":" + dt.getSeconds();
 
-    cont_splits = content.split("*_*");
+    // Split content by the log separator
+    var cont_splits = content.split("*_*");
+    var log_history_id = null;
 
-    log_history_id = null;
-
+    // Extract history ID if present
     if (cont_splits.length > 1) {
       log_history_id = cont_splits[0];
       let newArray = cont_splits.slice(1);
       content = newArray.join(" ");
     }
 
+    console.log("Log received - history_id: " + log_history_id + ", current process history_id: " + GW.process.history_id);
+
+    // Style based on content
     var style1 = "";
     if (content.includes("Start to execute")) {
       style1 = "color: blue; font-weight: bold; text-decoration: underline;";
-
-      $(".dot-flashing").removeClass("invisible");
-      $(".dot-flashing").addClass("visible");
-    } else if (content.includes("===== Process")) {
+      $(".dot-flashing").removeClass("invisible").addClass("visible");
+    } else if (content.includes("===== Process") || content.includes("Connected to process execution")) {
       style1 = "color: blue; font-weight: bold; text-decoration: underline;";
-
-      $(".dot-flashing").removeClass("visible");
-      $(".dot-flashing").addClass("invisible");
+      $(".dot-flashing").removeClass("visible").addClass("invisible");
     } else if (content == "disconnected") {
-      $(".dot-flashing").removeClass("visible");
-      $(".dot-flashing").addClass("invisible");
+      $(".dot-flashing").removeClass("visible").addClass("invisible");
     } else if (log_history_id == GW.process.history_id) {
-      $(".dot-flashing").removeClass("invisible");
-      $(".dot-flashing").addClass("visible");
+      // This log belongs to the current process
+      style1 = "color: green;";
+      $(".dot-flashing").removeClass("invisible").addClass("visible");
     } else {
-      $(".dot-flashing").removeClass("visible");
-      $(".dot-flashing").addClass("invisible");
+      $(".dot-flashing").removeClass("visible").addClass("invisible");
     }
 
+    // Create the HTML for the log line
     var newline =
       `<p style="line-height:1.1; text-align:left; margin-top: 10px; ` +
       `margin-bottom: 10px;"><span style="` +
@@ -231,31 +233,32 @@ GW.ssh = {
       content +
       `</span></p>`;
 
-    this.current_log_length += 1; //line number plus 1
-
+    // Add to main log window with limit
+    this.current_log_length += 1;
     if (this.current_log_length > 5000) {
       $("#log-window").find("p:first").remove();
       this.current_log_length -= 1;
     }
-
     $("#log-window").append(newline);
 
-    //don't output log to process log if the current executed is workflow
+    // Add to process-specific log window if it exists and matches current process
     if ($("#" + GW.ssh.process_output_id).length) {
+      // Manage process log length
       if (this.current_process_log_length > 5000) {
-        $("#" + GW.ssh.process_output_id)
-          .find("p:first")
-          .remove();
-
+        $("#" + GW.ssh.process_output_id).find("p:first").remove();
         this.current_process_log_length -= 1;
       }
 
-      if (GW.process.history_id == log_history_id) {
-        // only display the log if the current history id is the correct one
+      // Only display logs for the current process
+      if (log_history_id == null || GW.process.history_id == log_history_id) {
         $("#" + GW.ssh.process_output_id).append(newline);
+        // Scroll to bottom of log window
+        var logWindow = document.getElementById(GW.ssh.process_output_id);
+        if (logWindow) {
+          logWindow.scrollTop = logWindow.scrollHeight;
+        }
+        this.current_process_log_length += 1;
       }
-
-      this.current_process_log_length += 1;
     }
   },
 
@@ -281,56 +284,83 @@ GW.ssh = {
   },
 
   startLogSocket: function (token) {
+    // Close existing connection if any
     if (GW.ssh.all_ws) GW.ssh.all_ws.close();
-
-    GW.ssh.all_ws = new WebSocket(this.getWsPrefixURL() + "command-socket");
-
-    GW.ssh.ws = GW.ssh.all_ws;
-
+    
     GW.ssh.output_div_id = "log_box_id";
-
     GW.ssh.token = token; //token is the jsession id
-
-    //			this.echo("Running process " + token)
-
-    GW.ssh.all_ws.onopen = function (e) {
-      GW.ssh.ws_onopen(e);
+    
+    // Initialize the communication module with the token and message handler
+    GW.communication.init(token, function(message) {
+      // This is the message handler that will be called for both WebSocket and long polling
+      if (message.indexOf("Session_Status:Active") != -1) {
+        GW.ssh.checker_swich = false;
+      } else if (
+        message.indexOf(GW.ssh.special.prompt) == -1 &&
+        message.indexOf(GW.ssh.special.ready) == -1 &&
+        message.indexOf("No SSH connection is active") == -1
+      ) {
+        GW.ssh.echo(message);
+      }
+    });
+    
+    // Set up references to the communication module
+    GW.ssh.all_ws = {
+      // Provide a compatible interface for existing code
+      close: function() {
+        GW.communication.close();
+      },
+      send: function(data) {
+        GW.communication.send(data);
+      },
+      readyState: function() {
+        return GW.communication.isConnected ? WebSocket.OPEN : WebSocket.CLOSED;
+      }
     };
-
-    GW.ssh.all_ws.onclose = function (e) {
-      GW.ssh.ws_onclose(e);
-    };
-
-    GW.ssh.all_ws.onmessage = function (e) {
-      GW.ssh.ws_onmessage(e);
-    };
-
-    GW.ssh.all_ws.onerror = function (e) {
-      GW.ssh.ws_onerror(e);
-    };
+    
+    GW.ssh.ws = GW.ssh.all_ws;
   },
 
-  connectWsSessionWithExecution: function (msg) {},
+  connectWsSessionWithExecution: function (msg) {
+    // This function connects the WebSocket session with a process execution
+    // by associating the history_id with the current session
+    
+    // Store the history ID for reference
+    GW.process.history_id = msg.history_id;
+    
+    // Ensure we have an active communication connection
+    if (GW.ssh.all_ws != null) {
+      // Check connection and reconnect if needed
+      GW.communication.checkConnection();
+    } else {
+      console.log("No communication connection exists. Establishing connection...");
+      GW.ssh.startLogSocket(msg.token);
+    }
+    
+    // Send a message to the server to associate this session with the execution
+    setTimeout(function() {
+      GW.ssh.send("execution:" + msg.history_id);
+      // Clear any existing logs in the process log window
+      if ($("#" + GW.ssh.process_output_id).length) {
+        $("#" + GW.ssh.process_output_id).html("");
+      }
+      // Add initial log message to confirm connection
+      GW.ssh.addlog(msg.history_id + GW.utils.BaseTool.log_separator + "=======\nConnected to process execution: " + msg.history_id);
+    }, 1000);
+    
+    console.log("WebSocket session connected with execution ID: " + msg.history_id);
+  },
 
   openLog: function (msg) {
-    //check if the websocket session is alive, otherwise, restore the connection
-
-    if (
-      GW.ssh.all_ws != null &&
-      (GW.ssh.all_ws.readyState === WebSocket.CLOSED ||
-        GW.ssh.all_ws.readyState === WebSocket.CLOSING)
-    ) {
-      // GW.ssh.all_ws.close();
-
-      console.log(
-        "The command websocket connection is detected to be closed. Try to reconnect...",
-      );
-
-      GW.ssh.startLogSocket(msg.token);
-
-      console.log("The console websocket connection is restored..");
+    // Check if the communication connection is alive, otherwise restore it
+    // This will work with both WebSocket and long polling fallback
+    
+    if (GW.ssh.all_ws != null) {
+      // Check connection and reconnect if needed
+      GW.communication.checkConnection();
     } else {
-      GW.ssh.checkSessionStatus();
+      console.log("No communication connection exists. Establishing connection...");
+      GW.ssh.startLogSocket(msg.token);
     }
 
     if (msg.history_id.length == 12)
@@ -338,5 +368,35 @@ GW.ssh = {
     else this.addlog("=======\nStart to execute Workflow " + msg.history_id);
   },
 
-  openTerminal: function (token, terminal_div_id) {},
+  openTerminal: function (token, terminal_div_id) {
+    // This function sets up a terminal interface in the specified div
+    
+    // Store the token and output div ID
+    GW.ssh.token = token;
+    GW.ssh.output_div_id = terminal_div_id;
+    
+    // Clear any existing content in the terminal div
+    $("#" + terminal_div_id).html("");
+    
+    // Add terminal-specific styling to the div
+    $("#" + terminal_div_id).addClass("terminal-container");
+    
+    // Initialize the communication connection if it doesn't exist
+    if (GW.ssh.all_ws == null) {
+      GW.ssh.startLogSocket(token);
+    } else {
+      // Check connection and reconnect if needed
+      GW.communication.checkConnection();
+    }
+    
+    // Send a message to the server to initialize the terminal
+    setTimeout(function() {
+      GW.ssh.send("terminal:init");
+    }, 1000);
+    
+    // Add a welcome message to the terminal
+    GW.ssh.echo("Terminal connected. Type commands to interact with the server.");
+    
+    console.log("Terminal opened in div: " + terminal_div_id);
+  },
 };

--- a/src/main/resources/static/js/gw.ssh.js
+++ b/src/main/resources/static/js/gw.ssh.js
@@ -289,8 +289,9 @@ GW.ssh = {
     GW.ssh.token = token; //token is the jsession id
     
     // Initialize the communication module with the token and message handler
+    // Using polling as the primary and only communication method
     GW.communication.init(token, function(message) {
-      // This is the message handler that will be called for both WebSocket and long polling
+      // This is the message handler that will be called for polling
       if (message.indexOf("Session_Status:Active") != -1) {
         GW.ssh.checker_swich = false;
       } else if (
@@ -303,8 +304,8 @@ GW.ssh = {
     });
     
     // Set up references to the communication module
+    // Maintain the same interface for backward compatibility
     GW.ssh.all_ws = {
-      // Provide a compatible interface for existing code
       close: function() {
         GW.communication.close();
       },

--- a/src/main/resources/static/js/gw.workspace.js
+++ b/src/main/resources/static/js/gw.workspace.js
@@ -1448,56 +1448,72 @@ GW.workspace = {
 
     GW.workspace.GraphCreator.prototype.renderStatus = function (statusList) {
 
-      console.log("monitor workflow status called");
+      console.log("monitor workflow status called", statusList);
 
+      // Handle single process update
       if (statusList.message_type == "single_process") {
-
         var id = statusList.id;
-
         var history_id = statusList.history_id;
-
         var flag = statusList.status; //true or false
-
         var num = this.getNodeNumById(id);
-
-        GW.workspace.theGraph.nodes[num].color = GW.workspace.getColorByFlag(flag);
-
-        GW.workspace.theGraph.nodes[num].status = flag;
-
-        GW.monitor.updateProgress(id, flag);
+        
+        if (num !== null) {
+          GW.workspace.theGraph.nodes[num].color = GW.workspace.getColorByFlag(flag);
+          GW.workspace.theGraph.nodes[num].status = flag;
+          GW.monitor.updateProgress(id, flag);
+        } else {
+          console.error("Node not found with id:", id);
+        }
 
         GW.workspace.theGraph.updateGraph();
-
-      } else if (typeof statusList === "object") {
-        var newnodes = [];
-
+      } 
+      // Handle array of status updates
+      else if (Array.isArray(statusList)) {
+        var updatedAnyNode = false;
+        
         for (var i = 0; i < statusList.length; i++) {
-          //single node
-
           var id = statusList[i].id;
-
           var flag = statusList[i].status; //true or false
-
-          var node = this.getNodeById(id);
-
-          node.color = GW.workspace.getColorByFlag(flag);
-
-          node.status = flag
-
-          newnodes.push(node);
-
-          GW.monitor.updateProgress(id, flag);
+          var num = this.getNodeNumById(id);
+          
+          if (num !== null) {
+            GW.workspace.theGraph.nodes[num].color = GW.workspace.getColorByFlag(flag);
+            GW.workspace.theGraph.nodes[num].status = flag;
+            GW.monitor.updateProgress(id, flag);
+            updatedAnyNode = true;
+          } else {
+            console.error("Node not found with id:", id);
+          }
         }
-
-        if (newnodes.length == 0) {
-          console.error("Lost all the nodes");
-        } else {
-          GW.workspace.theGraph.nodes = newnodes;
-
+        
+        if (updatedAnyNode) {
           GW.workspace.theGraph.updateGraph();
         }
-
-        // console.log("circle should change its color");
+      } 
+      // Handle object with array property
+      else if (typeof statusList === "object" && statusList.length > 0) {
+        var updatedAnyNode = false;
+        
+        for (var i = 0; i < statusList.length; i++) {
+          var id = statusList[i].id;
+          var flag = statusList[i].status; //true or false
+          var num = this.getNodeNumById(id);
+          
+          if (num !== null) {
+            GW.workspace.theGraph.nodes[num].color = GW.workspace.getColorByFlag(flag);
+            GW.workspace.theGraph.nodes[num].status = flag;
+            GW.monitor.updateProgress(id, flag);
+            updatedAnyNode = true;
+          } else {
+            console.error("Node not found with id:", id);
+          }
+        }
+        
+        if (updatedAnyNode) {
+          GW.workspace.theGraph.updateGraph();
+        }
+      } else {
+        console.error("Unrecognized status update format:", statusList);
       }
     };
     /**

--- a/src/main/resources/templates/fragments/config/scripts.html
+++ b/src/main/resources/templates/fragments/config/scripts.html
@@ -12,6 +12,7 @@
 <script src="../js/gw.feedback.js"></script>
 <script src="../js/gw.chart.js"></script>
 <script src="../js/gw.workspace.js"></script>
+<script src="../js/gw.communication.js"></script>
 <script src="../js/gw.ssh.js"></script>
 <script src="../js/gw.fileupload.js"></script>
 <script src="../js/gw.filebrowser.js"></script>


### PR DESCRIPTION
Use polling as default communication channel. The speed increases significantly. 
Make Geoweaver no longer relying on web socket proxy when it is behind VPN or redirected gateway. 